### PR TITLE
add test declarations and set definition (for syncdir.py)

### DIFF
--- a/activations/io.macadmins.activation.test.json
+++ b/activations/io.macadmins.activation.test.json
@@ -1,0 +1,9 @@
+{
+    "Type": "com.apple.activation.simple",
+    "Payload": {
+        "StandardConfigurations": [
+            "io.macadmins.config.test"
+        ]
+    },
+    "Identifier": "io.macadmins.activation.test"
+}

--- a/configurations/io.macadmins.config.test.json
+++ b/configurations/io.macadmins.config.test.json
@@ -1,0 +1,7 @@
+{
+    "Type": "com.apple.configuration.management.test",
+    "Payload": {
+        "Echo": "KMFDDM"
+    },
+    "Identifier": "io.macadmins.config.test"
+}

--- a/sets/set.default.txt
+++ b/sets/set.default.txt
@@ -1,0 +1,4 @@
+io.macadmins.activation.test
+io.macadmins.config.test
+io.macadmins.activation.subs
+io.macadmins.config.subs


### PR DESCRIPTION
KMFDDM got a new `syncdir.py` script: jessepeterson/kmfddm#35. Add a sets.$SET.txt for that as well as some test declarations. Output from script running of this whole repo:

```sh
$ ~/go/src/github.com/jessepeterson/kmfddm/tools/syncdir.py --baseurl 'http://[::1]:9002' --key $API_KEY .
changed declaration io.macadmins.activation.test
changed declaration io.macadmins.config.test
associated declaration io.macadmins.activation.test with set default
associated declaration io.macadmins.config.test with set default
unchanged declarations: 23
changed declarations (2): io.macadmins.activation.test, io.macadmins.config.test
changed sets (1): default
sent notify
```

(Note the newest KMFDDM is required for the new-style delayed/collated notifications)