### PR TITLE
Update io.macadmins.asset.exampledaemon.json

### DIFF
--- a/assets/io.macadmins.asset.exampledaemon.json
+++ b/assets/io.macadmins.asset.exampledaemon.json
@@ -3,7 +3,7 @@
 	"Type": "com.apple.asset.data",
 	"Payload": {
 		"Reference": {
-			"ContentType": "text/xml",
+			"ContentType": "application/xml",
 			"DataURL": "https://files.macadmins.io/io.macadmins.exampledaemon.plist",
 			"Hash-SHA-256": "23b5ad7cd586dce311d0fe35a9032e5fd8de35bc8204fb14d33d878a7b0282c7"
 		},


### PR DESCRIPTION
ddm expects application/xml as the data type.